### PR TITLE
Fix: debugged and fixed close modal on click outside

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -39,13 +39,13 @@ const App = () => {
     };
 
     const clickClose = (e) => {
-      if (!e.target.closest("modal")) {
+      if (e.target.className.includes('modal__overlay')) {
         closeAllPopups();
       }
     };
 
-    document.addEventListener("mousedown", clickClose);
     document.addEventListener("keydown", closeByEsc);
+    document.addEventListener("mousedown", clickClose);
 
     return () => {
       document.removeEventListener("keydown", closeByEsc);

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -4,7 +4,6 @@
     right: 0;
     top: 0;
     bottom: 0;
-    background-color: rgba(0, 0, 0, 0.8);
 
     z-index: 999;
     pointer-events: none;
@@ -16,6 +15,10 @@
     opacity: 0;
     visibility: hidden;
     transition: opacity ease-out 0.5s, visibility 0s ease-out 0.5s;
+}
+
+.modal__overlay {
+    background-color: rgba(0, 0, 0, 0.8);
 }
 
 .modal_open {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -2,7 +2,7 @@ import "./Modal.css";
 
 const Modal = ({ isOpen, modalTitle, children, isSuccess, onClose }) => {
   return (
-    <div className={`modal ${isOpen && "modal_open"}`}>
+    <div className={`modal modal__overlay ${isOpen && "modal_open"}`}>
       <div className="modal__container">
         <button className="close-button" onClick={onClose}></button>
         <p


### PR DESCRIPTION
For this small PR, I

- Debugged code and adjusted the function that allows users to close modal when clicking outside of it.
- Added: `modal__overlay` css in `Modal`.