### PR TITLE
News Api

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -40,14 +40,16 @@ const App = () => {
    /** *************************************************************************************** */
 
   const handleNewsSearch = (userKeyword) => {
-    NewsApi.getNews(userKeyword)
-      .then((cardData) => {
-        setCards(cardData);
-        localStorage.setItem(cards, JSON.stringify(cards));
-      })
-      .catch((err) => {
-        console.log(err);
-      });
+    console.log(userKeyword);
+    // NewsApi.getNews(userKeyword)
+    //   .then((cardData) => {
+    //     console.log(cardData);
+    //     setCards(cardData);
+    //     localStorage.setItem(cards, JSON.stringify(cards));
+    //   })
+    //   .catch((err) => {
+    //     console.log(err);
+    //   });
   };
 
   /******************************************************************************************** */
@@ -126,7 +128,7 @@ const App = () => {
             path="/"
             element={
               <>
-                <SearchForm handleSubmit={handleNewsSearch}>
+                <SearchForm onSubmit={handleNewsSearch}>
                   <Header
                     isLoggedIn={isLoggedIn}
                     logoColor={"white"}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -44,7 +44,7 @@ const App = () => {
     console.log(userKeyword);
     // NewsApi.getNews(userKeyword)
     //   .then((cardData) => {
-    //     console.log(cardData);
+    //     cardData['keyword'] = userKeyword;
     //     localStorage.setItem("cards", JSON.stringify(cardData));
     //   })
     //   .then(() => {
@@ -58,6 +58,7 @@ const App = () => {
   const handleSearchResults = () => {
     const cardData = JSON.parse(localStorage.getItem("cards"));
     const newsArticles = cardData.articles;
+    newsArticles.forEach((article) => (article["keyword"] = cardData.keyword));
     setCards(newsArticles);
   };
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -15,6 +15,7 @@ import NavigationModal from "../NavigationModal/NavigationModal";
 import { NewsApi } from "../../utils/NewsExplorerApi";
 import placeholderCard from "../../utils/constants"; // only being used for testing
 import Main from "../Main/Main";
+import SearchResults from "../SearchResults/SearchResults";
 
 const App = () => {
   // placeholder
@@ -37,47 +38,55 @@ const App = () => {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
 
   /******************************************************************************************** */
-   /** *************************************************************************************** */
+  /** *************************************************************************************** */
 
   const handleNewsSearch = (userKeyword) => {
     console.log(userKeyword);
     // NewsApi.getNews(userKeyword)
     //   .then((cardData) => {
     //     console.log(cardData);
-    //     setCards(cardData);
-    //     localStorage.setItem(cards, JSON.stringify(cards));
+    //     localStorage.setItem("cards", JSON.stringify(cardData));
+    //   })
+    //   .then(() => {
+    //     handleSearchResults();
     //   })
     //   .catch((err) => {
     //     console.log(err);
     //   });
   };
 
+  const handleSearchResults = () => {
+    const cardData = JSON.parse(localStorage.getItem("cards"));
+    const newsArticles = cardData.articles;
+    setCards(newsArticles);
+  };
+
   /******************************************************************************************** */
   /************************************* Handles `Main` behavior *******************************/
-  
+
   const handleLoading = () => {
     setMain(true);
     setIsLoading(true);
-  }
+  };
 
   const handleSearchSuccess = () => {
     setMain(true);
     setResults(true);
-  }
+  };
 
   const handleNothingFound = () => {
     setMain(true);
     setIsNotFound(true);
-  }
+  };
 
   const closeMain = () => {
     setMain(false);
     setIsNotFound(false);
     setResults(false);
     setIsLoading(false);
-  }
+  };
 
-    /******************************************************************************************** */
+  /******************************************************************************************** */
   /** *************************************************************************************** */
 
   const closeAllPopups = () => {
@@ -128,7 +137,7 @@ const App = () => {
             path="/"
             element={
               <>
-                <SearchForm onSubmit={handleNewsSearch}>
+                <SearchForm onSubmit={handleSearchResults}>
                   <Header
                     isLoggedIn={isLoggedIn}
                     logoColor={"white"}
@@ -137,14 +146,16 @@ const App = () => {
                     openMobileModal={() => setIsMobileNavOpen(true)}
                   />
                 </SearchForm>
-                {main === true ? (
+
+                <SearchResults cards={cards} />
+                {/* {main === true ? (
                   <Main
                     isLoading={isLoading}
                     isNotFound={isNotFound}
                     isFound={results}
-                    cards={placeholderCard}
+                    cards={cards}
                   />
-                ) : null}
+                ) : null} */}
                 <About />
                 <Footer />
               </>

--- a/src/components/NewsCard/NewsCard.css
+++ b/src/components/NewsCard/NewsCard.css
@@ -8,6 +8,7 @@
 .news-card__container {
     margin: 0;
     padding: 0;
+    height: 576px;
     border-radius: 4%;
     background-color: #ffff;
     position: relative;
@@ -119,6 +120,8 @@
 .news-card__text-container {
     margin: 17px 0 0;
     padding: 0 24px 24px;
+    max-width: 352px;
+    max-height: 260px;
 }
 
 .news-card__date {
@@ -140,18 +143,23 @@
     font-weight: 400;
     font-size: 26px;
     line-height: 30px;
+
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
 }
 
 .news-card__text {
     margin: 0;
     padding: 0;
     max-width: 352px;
-    width: 100%;
-    height: 110px;
+    max-height: 110px;
 
-    text-overflow: ellipsis;
-    white-space: nowrap;
     overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
 
     font-family: 'Roboto';
     font-weight: 400;
@@ -160,8 +168,11 @@
 }
 
 .news-card__source {
-    margin: 18px 0 0;
+    margin: 0;
     padding: 0;
+
+    position: absolute;
+    bottom: 24px;
 
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -177,6 +188,10 @@
 @media screen and (max-width: 768px) {
     .news-card {
         max-width: 224px;
+    }
+
+    .news-card__container {
+        max-height: 420px;
     }
 
     .news-card__warning {
@@ -210,6 +225,8 @@
     }
     
     .news-card__text-container {
+        max-width: 193px;
+        max-height: 238px;
         margin: 16px 0 0;
         padding: 0 16px 16px 15px;
     }
@@ -218,6 +235,7 @@
         margin: 0 0 10px 0;
         font-size: 22px;
         line-height: 24px;
+        -webkit-line-clamp: 3;
     }
     
     .news-card__text {
@@ -228,8 +246,7 @@
     }
     
     .news-card__source {
-        margin: 12px 0 0;
-        padding: 0;
+        bottom: 16px;
     }
 }
 
@@ -240,6 +257,7 @@
     
     .news-card__container {
         width: 288px;
+        max-height: 440px;
     }
     
     /** Disallows users to save articles if not signed in. Warning message **/
@@ -264,6 +282,8 @@
     }
     
     .news-card__text-container {
+        max-width: 256px;
+        height: 184px;
         margin: 16px 0 0;
         padding: 0 16px 16px;
     }
@@ -273,16 +293,15 @@
     }
     
     .news-card__title {
-        max-width: 192px;
+        max-width: 256px;
         margin: 0 0 14px 0;
     }
     
     .news-card__text {
         max-width: 256px;
-        height: 88px;
+        height: 70px;
+
+        overflow: hidden;
+        -webkit-line-clamp: 3;
     }
-    
-    .news-card__source {
-        margin: 8px 0 0;
-    } 
 }

--- a/src/components/NewsCard/NewsCard.js
+++ b/src/components/NewsCard/NewsCard.js
@@ -14,7 +14,7 @@ const NewsCard = ({
   isLoggedIn,
   onSaveClick,
   onDeleteClick,
-  card
+  card,
 }) => {
   const [isShown, setIsShown] = useState("_hidden");
 
@@ -28,6 +28,15 @@ const NewsCard = ({
     default:
       message = "Sign in to save articles";
   }
+
+  const convertedPublishedDate = new Date(card.publishedAt).toLocaleString(
+    "default",
+    {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    }
+  );
 
   const handleDeleteClick = () => {
     console.log("I should be deleted!");
@@ -70,18 +79,12 @@ const NewsCard = ({
         >
           {card.key}
         </span>
-        <img
-          className="news-card__image"
-          src={card.urlToImage}
-          alt="Card"
-        />
+        <img className="news-card__image" src={card.urlToImage} alt="Card" />
         <div className="news-card__text-container">
-          <p className="news-card__date">{card.publishedAt}</p>
+          <p className="news-card__date">{convertedPublishedDate}</p>
           <p className="news-card__title">{card.title}</p>
           <p className="news-card__text">{card.description}</p>
-          <p className="news-card__source">
-            {card.source.name.toUpperCase()}
-          </p>
+          <p className="news-card__source">{card.source.name.toUpperCase()}</p>
         </div>
       </div>
     </div>

--- a/src/components/NewsCard/NewsCard.js
+++ b/src/components/NewsCard/NewsCard.js
@@ -72,15 +72,15 @@ const NewsCard = ({
         </span>
         <img
           className="news-card__image"
-          src={card.image}
+          src={card.urlToImage}
           alt="Card"
         />
         <div className="news-card__text-container">
-          <p className="news-card__date">{card.date}</p>
+          <p className="news-card__date">{card.publishedAt}</p>
           <p className="news-card__title">{card.title}</p>
-          <p className="news-card__text">{card.text}</p>
+          <p className="news-card__text">{card.description}</p>
           <p className="news-card__source">
-            {card.source.toUpperCase()}
+            {card.source.name.toUpperCase()}
           </p>
         </div>
       </div>

--- a/src/components/NewsCard/NewsCard.js
+++ b/src/components/NewsCard/NewsCard.js
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 
 import "./NewsCard.css";
-import placeholderImg from "../../images/card-placeholder.png";
 
 /** NewsCard Component
  * takes the data from the news API and places it in correct place.
@@ -77,7 +76,7 @@ const NewsCard = ({
               : "news-card__keyword news-card__keyword_hidden"
           }
         >
-          {card.key}
+          {card.keyword}
         </span>
         <img className="news-card__image" src={card.urlToImage} alt="Card" />
         <div className="news-card__text-container">

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -13,8 +13,7 @@ const SearchForm = ({ onSubmit, children }) => {
     const userKeyword = {
       keyword,
     };
-    console.log(userKeyword);
-    // onSubmit(userKeyword);
+    onSubmit(userKeyword);
   };
 
   const handleInputReset = () => {

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -10,10 +10,7 @@ const SearchForm = ({ onSubmit, children }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    const userKeyword = {
-      keyword,
-    };
-    onSubmit(userKeyword);
+    onSubmit(keyword);
   };
 
   const handleInputReset = () => {

--- a/src/utils/NewsExplorerApi.js
+++ b/src/utils/NewsExplorerApi.js
@@ -12,21 +12,16 @@ class NewsExplorerApi {
   getNews(userTopic) {
     const presentDay = new Date().toISOString().slice(0, 10);
 
-    const getLastWeek = () => {
-      const today = new Date();
-      const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
-        .toISOString()
-        .slice(0, 10);
-
-      return lastWeek;
-    };
+    const today = new Date();
+    const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
 
     return fetch(
-      `${this._baseURL}/everything?q="${userTopic}"&from=${getLastWeek}to=${presentDay}&pageSize=100`,
+      `${this._baseURL}/everything?q="${userTopic}"&from=${lastWeek}to=${presentDay}&pageSize=100&apiKey=${this._key}`,
       {
         method: "GET",
         headers: {
-          Authorization: this._key,
           ...this._headers,
         },
       }
@@ -36,5 +31,5 @@ class NewsExplorerApi {
 
 export const NewsApi = new NewsExplorerApi({
   baseURL: "https://newsapi.org/v2",
-  key: process.env.NEWS_API_KEY,
+  key: "5e69260d0afd4eb383a753b851075b27",
 });


### PR DESCRIPTION
In this PR, I

- Adjusted `handleNewsSearch` in `App.js` and temporarily commented it out. 
> It takes the data from the `NewsExplorerApi` api and stores it in local storage.

- Created `handleSearchResults` in `App.js` that pulls the data from local storage, grabs the articles and sets the results cards.
- Adjusted some `NewsCard` css to handle data from news api.
- Added logic to convert the `publishedAt` data to proper format.
- Adjusted submit in `SearchForm` to return a string instead of an object.
- Moved news api key from `.env` to `utils/NewsExplorerApi.js`.
- Added logic to `handleNewsSearch` and `handleSearchResults` to add user's keyword to `NewsExplorerApi` returned data.